### PR TITLE
fix: Resolve vibe_check_mentor generic responses issue

### DIFF
--- a/src/vibe_check/mentor/response/generators/ai_engineer.py
+++ b/src/vibe_check/mentor/response/generators/ai_engineer.py
@@ -47,7 +47,7 @@ class AIEngineerGenerator(BasePersonaGenerator):
     ) -> Tuple[str, str, float]:
         """Enhance response based on topic keywords"""
         ai_keywords = ["integration", "ai", "mcp", "claude", "tool"]
-        if self._has_topic_keywords(topic, ai_keywords):
+        if self.has_topic_keywords(topic, ai_keywords):
             # For AI-related topics, use specialized integration insight
             return AIEngineerHandler.get_integration_insight(topic)
         

--- a/src/vibe_check/mentor/response/generators/base_generator.py
+++ b/src/vibe_check/mentor/response/generators/base_generator.py
@@ -8,7 +8,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional, Tuple
 
 from ...models.session import ContributionData
-from ...patterns.base import PatternHandler
+from ...patterns.handlers.base import PatternHandler
 
 
 class BasePersonaGenerator(PatternHandler, ABC):

--- a/src/vibe_check/mentor/response/generators/product_engineer.py
+++ b/src/vibe_check/mentor/response/generators/product_engineer.py
@@ -49,7 +49,7 @@ class ProductEngineerGenerator(BasePersonaGenerator):
     ) -> Tuple[str, str, float]:
         """Enhance response based on topic keywords"""
         build_keywords = ["build", "create", "implement"]
-        if self._has_topic_keywords(topic, build_keywords):
+        if self.has_topic_keywords(topic, build_keywords):
             enhancement = f"Before building '{topic}', have we validated this solves a real user problem? I'd rather ship something imperfect that users love than something perfect they don't need."
             return self._enhance_content(base_response, enhancement)
         

--- a/src/vibe_check/mentor/response/generators/senior_engineer.py
+++ b/src/vibe_check/mentor/response/generators/senior_engineer.py
@@ -36,7 +36,7 @@ class SeniorEngineerGenerator(BasePersonaGenerator):
     ) -> Tuple[str, str, float]:
         """Enhance response based on detected patterns"""
         # Check for infrastructure-without-implementation pattern
-        if self._has_pattern(patterns, "infrastructure_without_implementation"):
+        if self.has_pattern(patterns, "infrastructure_without_implementation"):
             infra_response = InfrastructurePatternHandler.get_senior_engineer_response()
             enhancement = f"Specifically for '{topic}', I'd recommend checking if there's an official SDK or documented API that handles this use case."
             return self._enhance_content(infra_response, enhancement)
@@ -50,7 +50,7 @@ class SeniorEngineerGenerator(BasePersonaGenerator):
     ) -> Tuple[str, str, float]:
         """Enhance response based on topic keywords"""
         integration_keywords = ["api", "integration", "service"]
-        if self._has_topic_keywords(topic, integration_keywords):
+        if self.has_topic_keywords(topic, integration_keywords):
             enhancement = f"For integrations like '{topic}', I always check the official documentation first - it often shows simpler approaches than what we initially consider."
             return self._enhance_content(base_response, enhancement)
         

--- a/src/vibe_check/strategies/response_strategies.py
+++ b/src/vibe_check/strategies/response_strategies.py
@@ -58,14 +58,24 @@ class LLMComparisonStrategy(ResponseStrategy):
     
     def can_handle(self, tech_context: TechnicalContext, query: str) -> bool:
         llm_terms = ['gpt', 'claude', 'gemini', 'sonnet', 'opus', 'o3', 'nano', 'mini', 'haiku', 'deepseek']
+        query_lower = query.lower()
         
-        # Check query text
-        if any(term in query.lower() for term in llm_terms):
+        # MUST have comparison indicators AND LLM terms to trigger
+        comparison_indicators = ['vs', 'versus', 'compare', 'comparison', 'which', 'better', 'choose', 'pick']
+        has_comparison = any(indicator in query_lower for indicator in comparison_indicators)
+        
+        # Check if query contains LLM terms
+        has_llm_terms = any(term in query_lower for term in llm_terms)
+        
+        # Only handle if it's actually comparing LLMs, not just mentioning them
+        if has_llm_terms and has_comparison:
             return True
         
-        # Check decision points
+        # Check decision points for explicit LLM comparisons
         if any(term in dp.lower() for dp in tech_context.decision_points for term in ['gpt', 'claude', 'gemini', 'deepseek']):
-            return True
+            # Only if decision point also has comparison language
+            if any(indicator in dp.lower() for dp in tech_context.decision_points for indicator in comparison_indicators):
+                return True
         
         return False
     

--- a/src/vibe_check/tools/vibe_mentor.py
+++ b/src/vibe_check/tools/vibe_mentor.py
@@ -55,7 +55,7 @@ class VibeMentorEngine:
         self.session_manager = SessionManager()
         self.response_coordinator = ResponseCoordinator() 
         self.pattern_detector = PatternDetector()
-        self._enhanced_mode = True  # Flag to enable enhanced reasoning
+        self._enhanced_mode = False  # Flag to enable enhanced reasoning - DISABLED to fix generic responses
 
     # Delegate session management to SessionManager
     def create_session(


### PR DESCRIPTION
## Summary

Fixes the critical issue where `vibe_check_mentor` was returning generic "Budget LLMs for 2025" and "ship gpt + solid this week" responses instead of analyzing the actual user query.

## Problem

Despite the v0.4.6 phase parameter fix, users were still getting unrelated generic advice when asking about domain-specific topics like email domain fallback for lead enrichment.

## Root Cause

1. **Enhanced Mode Override**: `VibeMentorEngine` had `_enhanced_mode = True`, calling the old `EnhancedVibeMentorEngine`
2. **Strategy Selection Bug**: `LLMComparisonStrategy.can_handle()` was too broad - triggered on any LLM terms like "nano" 
3. **Hardcoded Responses**: The enhanced version used response strategies with hardcoded generic responses

## Solution

1. **Disabled Enhanced Mode**: Set `_enhanced_mode = False` to use the new refactored persona system
2. **Fixed Strategy Matching**: Updated `LLMComparisonStrategy` to require both LLM terms AND comparison indicators ("vs", "compare", "which", etc.)
3. **Fixed Method Names**: Corrected `_has_pattern` → `has_pattern` and `_has_topic_keywords` → `has_topic_keywords`
4. **Fixed Import Path**: Updated `base_generator.py` import path

## Test Results

✅ **Before**: "Budget LLMs for 2025 (research-backed pricing): GPT-4.1 nano: $0.075/$0.3..."
✅ **After**: "For long-term maintainability, I suggest starting with the simplest solution that works..."

## Files Changed

- `src/vibe_check/tools/vibe_mentor.py` - Disabled enhanced mode
- `src/vibe_check/strategies/response_strategies.py` - Fixed LLMComparisonStrategy matching
- `src/vibe_check/mentor/response/generators/` - Fixed method names in persona generators
- `src/vibe_check/mentor/response/generators/base_generator.py` - Fixed import path

The `vibe_check_mentor` now provides contextual, relevant advice using the refactored persona system instead of generic tech responses.