### PR TITLE
fix: remove incorrect await from synchronous generate_contribution call (#214)

### DIFF
--- a/src/vibe_check/server.py
+++ b/src/vibe_check/server.py
@@ -1609,7 +1609,7 @@ async def vibe_check_mentor(
                 persona = session.personas[i]
                 session.active_persona_id = persona.id
                 
-                contribution = await engine.generate_contribution(
+                contribution = engine.generate_contribution(
                     session=session,
                     persona=persona,
                     detected_patterns=detected_patterns,


### PR DESCRIPTION
## Summary

Fixes critical bug #214 where `vibe_check_mentor` was failing with "object ContributionData can't be used in 'await' expression" error.

## Root Cause

Line 1612 in `server.py` was incorrectly using `await` on `engine.generate_contribution()`, but this method is synchronous and returns `ContributionData` directly (not a coroutine).

## Fix

**Single line change**: Remove `await` keyword from line 1612

```diff
- contribution = await engine.generate_contribution(
+ contribution = engine.generate_contribution(
```

## Verification

✅ Tested with comprehensive script - `vibe_check_mentor` now works without async/await errors  
✅ Returns expected `ContributionData` object  
✅ No functional changes to the actual logic

## Type: Hotfix

Critical bug fix with minimal risk - single keyword removal to fix async/await mismatch.