### PR TITLE
[Bug]: Fix YAML syntax error in issue-validation workflow

### DIFF
--- a/.github/workflows/issue-validation.yml
+++ b/.github/workflows/issue-validation.yml
@@ -141,4 +141,3 @@ jobs:
                 labels: ['phase2']
               });
             }
-EOF < /dev/null


### PR DESCRIPTION
## Summary

Fixes #241 - Removes invalid YAML syntax that was causing the issue-validation workflow to fail on every run.

## Problem

The `.github/workflows/issue-validation.yml` workflow has been consistently failing due to a YAML parsing error on line 144. The line contained `EOF < /dev/null` - a bash heredoc artifact that is not valid YAML syntax.

## Changes

- ✅ Removed invalid `EOF < /dev/null` from line 144
- ✅ Validated YAML syntax with `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/issue-validation.yml'))"`
- ✅ File now properly ends after the closing brace on line 143

## Test Plan

- [x] YAML syntax validation passes locally
- [ ] Workflow triggers successfully on issue events (will verify after merge)
- [ ] Auto-labeling functionality restored
- [ ] Status tracking automation works as expected

## Impact

**Before:**
- ❌ All workflow runs failing with YAML parse error
- ❌ No automated issue validation or labeling
- ❌ Manual triage required for all issues

**After:**  
- ✅ Workflow runs successfully
- ✅ Automated label validation restored
- ✅ Auto-labeling for anti-patterns and phases functional
- ✅ Status tracking automation operational