### PR TITLE
Fix legacy VibeCheckFramework import paths in unit tests

### DIFF
--- a/tests/unit/test_vibe_check_framework_claude_integration.py
+++ b/tests/unit/test_vibe_check_framework_claude_integration.py
@@ -32,7 +32,7 @@ class TestVibeCheckFrameworkClaudeIntegration:
     @pytest.fixture
     def framework(self):
         """Create framework instance for testing"""
-        with patch("vibe_check.tools.vibe_check_framework.Github"):
+        with patch("vibe_check.tools.legacy.vibe_check_framework.Github"):
             return VibeCheckFramework()
 
     @patch("shutil.which")

--- a/tests/unit/test_vibe_check_framework_core.py
+++ b/tests/unit/test_vibe_check_framework_core.py
@@ -67,12 +67,12 @@ class TestVibeCheckFrameworkCore:
     @pytest.fixture
     def framework(self, mock_github_token):
         """Create framework instance for testing"""
-        with patch("vibe_check.tools.vibe_check_framework.Github"):
+        with patch("vibe_check.tools.legacy.vibe_check_framework.Github"):
             return VibeCheckFramework(github_token=mock_github_token)
 
     def test_framework_initialization(self, mock_github_token):
         """Test proper framework initialization"""
-        with patch("vibe_check.tools.vibe_check_framework.Github") as mock_github:
+        with patch("vibe_check.tools.legacy.vibe_check_framework.Github") as mock_github:
             framework = VibeCheckFramework(github_token=mock_github_token)
 
             # Verify initialization
@@ -83,7 +83,7 @@ class TestVibeCheckFrameworkCore:
 
     def test_framework_initialization_without_token(self):
         """Test framework initialization without GitHub token"""
-        with patch("vibe_check.tools.vibe_check_framework.Github") as mock_github:
+        with patch("vibe_check.tools.legacy.vibe_check_framework.Github") as mock_github:
             framework = VibeCheckFramework()
 
             # Should use default GitHub() constructor

--- a/tests/unit/test_vibe_check_framework_github_integration.py
+++ b/tests/unit/test_vibe_check_framework_github_integration.py
@@ -31,7 +31,7 @@ class TestVibeCheckFrameworkGitHubIntegration:
     @pytest.fixture
     def framework(self):
         """Create framework instance for testing"""
-        with patch("vibe_check.tools.vibe_check_framework.Github"):
+        with patch("vibe_check.tools.legacy.vibe_check_framework.Github"):
             return VibeCheckFramework()
 
     def test_post_vibe_check_comment_success(self, framework):
@@ -206,14 +206,14 @@ class TestVibeCheckFrameworkGitHubIntegration:
 
     def test_github_client_initialization_with_token(self):
         """Test GitHub client initialization with token"""
-        with patch("vibe_check.tools.vibe_check_framework.Github") as mock_github:
+        with patch("vibe_check.tools.legacy.vibe_check_framework.Github") as mock_github:
             framework = VibeCheckFramework(github_token="test_token")
 
             mock_github.assert_called_once_with("test_token")
 
     def test_github_client_initialization_without_token(self):
         """Test GitHub client initialization without token"""
-        with patch("vibe_check.tools.vibe_check_framework.Github") as mock_github:
+        with patch("vibe_check.tools.legacy.vibe_check_framework.Github") as mock_github:
             framework = VibeCheckFramework()
 
             mock_github.assert_called_once_with()


### PR DESCRIPTION
## Summary
- update Github patches in VibeCheckFramework unit tests to reference the legacy module path
- ensure Claude and GitHub integration tests patch the relocated framework module

## Testing
- `export PYTHONPATH=src:. && pytest tests/unit/test_vibe_check_framework_core.py -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_b_68ddfd4b82288325b62913f79228bed6