### PR TITLE
Restore MCP sampling security compatibility modules

### DIFF
--- a/src/vibe_check/mentor/mcp_sampling_migration.py
+++ b/src/vibe_check/mentor/mcp_sampling_migration.py
@@ -1,0 +1,37 @@
+"""Compatibility shim for secure MCP sampling migration helpers.
+
+The comprehensive migration layer lives in
+``vibe_check.mentor.deprecated.mcp_sampling_migration`` while the refactor is
+finalised.  The original public module path –
+``vibe_check.mentor.mcp_sampling_migration`` – disappeared during the cleanup,
+which broke the security regression suite.  This module restores that public
+API by re-exporting the secure migration helpers from the deprecated package.
+"""
+
+from __future__ import annotations
+
+from .deprecated.mcp_sampling_migration import (
+    EnhancedSecretsScanner,
+    FileAccessController,
+    QueryInput,
+    RateLimiter,
+    SafeTemplateRenderer,
+    SecureMCPSamplingClient,
+    SecurePromptBuilder,
+    SecurePromptTemplate,
+    WorkspaceDataInput,
+    migrate_to_secure_client,
+)
+
+__all__ = [
+    "EnhancedSecretsScanner",
+    "FileAccessController",
+    "QueryInput",
+    "RateLimiter",
+    "SafeTemplateRenderer",
+    "SecureMCPSamplingClient",
+    "SecurePromptBuilder",
+    "SecurePromptTemplate",
+    "WorkspaceDataInput",
+    "migrate_to_secure_client",
+]

--- a/src/vibe_check/mentor/mcp_sampling_secure.py
+++ b/src/vibe_check/mentor/mcp_sampling_secure.py
@@ -1,0 +1,16 @@
+"""Backward-compatible alias for :mod:`vibe_check.mentor.mcp_sampling_security`.
+
+Historically callers imported the hardened MCP sampling helpers from
+``mcp_sampling_secure``.  During the ongoing refactor the implementation was
+moved into the deprecated namespace and the public shim was accidentally
+removed.  Re-introducing this alias keeps existing imports working while
+pointing everything to :mod:`mcp_sampling_security` where the compatibility
+layer lives.
+"""
+
+from __future__ import annotations
+
+from .mcp_sampling_security import *  # noqa: F401,F403
+from .mcp_sampling_security import __all__ as _security_all
+
+__all__ = list(_security_all)

--- a/src/vibe_check/mentor/mcp_sampling_security.py
+++ b/src/vibe_check/mentor/mcp_sampling_security.py
@@ -1,0 +1,41 @@
+"""Compatibility layer exposing secure MCP sampling components.
+
+This module re-exports the hardened implementations that previously lived in
+``vibe_check.mentor.deprecated.mcp_sampling_secure`` so that the rest of the
+codebase (and third-party extensions) can continue to import from
+``vibe_check.mentor.mcp_sampling_security``.  The secure components provide
+input validation, sandboxed template rendering, file access controls, rate
+limiting, and secrets scanning that are required for the security regression
+suite.
+
+The actual implementations continue to live in the deprecated namespace while
+we finish the migration.  Keeping this lightweight compatibility shim avoids
+code duplication while restoring the public API that the tests – and downstream
+callers – expect.
+"""
+
+from __future__ import annotations
+
+from .deprecated.mcp_sampling_secure import (
+    EnhancedSecretsScanner,
+    FileAccessController,
+    FilePathInput,
+    QueryInput,
+    RateLimiter,
+    SafeTemplateRenderer,
+    TokenBucket,
+    WorkspaceDataInput,
+    sanitize_code_for_llm,
+)
+
+__all__ = [
+    "EnhancedSecretsScanner",
+    "FileAccessController",
+    "FilePathInput",
+    "QueryInput",
+    "RateLimiter",
+    "SafeTemplateRenderer",
+    "TokenBucket",
+    "WorkspaceDataInput",
+    "sanitize_code_for_llm",
+]


### PR DESCRIPTION
## Summary
- add a public mcp_sampling_security compatibility shim that re-exports the secure helpers from the deprecated package
- provide a backward-compatible mcp_sampling_secure alias and restore the migration shim module used by the security patches

## Testing
- `export PYTHONPATH=src:. && pytest tests/security/test_mcp_sampling_security.py -v` *(fails: existing secure prompt builder and rate limiter expectations are not met by current implementation)*
- `export PYTHONPATH=src:. && pytest tests/security/ -v` *(fails: multiple pre-existing security hardening gaps remain outside the restored module)*

------
https://chatgpt.com/codex/tasks/task_b_68df0367e17c8325810a15d04acb8a82