### PR TITLE
Fix legacy mentor imports and package data assets

### DIFF
--- a/src/vibe_check/data/__init__.py
+++ b/src/vibe_check/data/__init__.py
@@ -1,0 +1,8 @@
+"""Package providing bundled data assets for Vibe Check."""
+
+from pathlib import Path
+
+DATA_DIR = Path(__file__).resolve().parent
+RESPONSE_BANK_PATH = DATA_DIR / "response_bank.json"
+
+__all__ = ["DATA_DIR", "RESPONSE_BANK_PATH"]

--- a/src/vibe_check/mentor/deprecated/__init__.py
+++ b/src/vibe_check/mentor/deprecated/__init__.py
@@ -1,0 +1,16 @@
+"""Deprecated mentor modules retained for backwards compatibility.
+
+These helpers power the transitional compatibility layer exposed via
+``vibe_check.mentor.mcp_sampling_security``.  Shipping them as a proper
+package ensures editable installs include the legacy modules so that
+imports like ``vibe_check.mentor.deprecated.mcp_sampling_secure`` remain
+available to security regression tests and downstream extensions.
+"""
+
+__all__ = [
+    "mcp_sampling_migration",
+    "mcp_sampling_optimized",
+    "mcp_sampling_patch",
+    "mcp_sampling_secure",
+    "mcp_sampling_ultrafast",
+]

--- a/src/vibe_check/tools/legacy/__init__.py
+++ b/src/vibe_check/tools/legacy/__init__.py
@@ -1,0 +1,13 @@
+"""Legacy MCP tool implementations kept for backward compatibility."""
+
+from .review_pr_monolithic_backup import PRReviewTool
+from .vibe_check_framework import (
+    VibeCheckFramework,
+    get_vibe_check_framework,
+)
+
+__all__ = [
+    "PRReviewTool",
+    "VibeCheckFramework",
+    "get_vibe_check_framework",
+]

--- a/src/vibe_check/tools/semantic_engine.py
+++ b/src/vibe_check/tools/semantic_engine.py
@@ -17,9 +17,12 @@ import logging
 from typing import Dict, List, Tuple, Optional, Any
 from dataclasses import dataclass
 from pathlib import Path
+
 import numpy as np
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
+
+from ..data import RESPONSE_BANK_PATH
 
 logger = logging.getLogger(__name__)
 
@@ -380,7 +383,7 @@ class SemanticResponseMatcher:
 
     def _get_default_response_path(self) -> Path:
         """Get default path for response bank"""
-        return Path(__file__).parent.parent / "data" / "response_bank.json"
+        return RESPONSE_BANK_PATH
 
     def _load_response_bank(self) -> Dict[str, List[Dict[str, Any]]]:
         """Load response bank from JSON file"""


### PR DESCRIPTION
## Summary
- add package initialisers for the deprecated mentor compatibility layer and legacy tools so editable installs expose the modules required by downstream imports
- expose packaged data paths via `vibe_check.data` and reuse the constant from the semantic response matcher

## Testing
- pytest tests/security/test_mcp_sampling_security.py -q

------
https://chatgpt.com/codex/tasks/task_b_68df0936d2f883258d527c6bb7b83634