### PR TITLE
Fix doom loop session status and async test configuration

### DIFF
--- a/src/vibe_check/core/doom_loop_detector.py
+++ b/src/vibe_check/core/doom_loop_detector.py
@@ -317,11 +317,18 @@ class DoomLoopDetector:
     def get_session_health_report(self) -> Dict[str, Any]:
         """Get a comprehensive health report for the current session"""
         if not self.current_session:
-            return {"status": "no_active_session"}
+            return {
+                "status": "no_active_session",
+                "doom_loop_detected": False,
+                "health_score": 100,
+                "recommendations": None,
+            }
 
         loop_pattern = self.analyze_current_session()
+        status = "doom_loop_detected" if loop_pattern else "healthy_session"
 
         return {
+            "status": status,
             "session_id": self.current_session.session_id,
             "duration_minutes": self.current_session.session_duration_minutes,
             "total_mcp_calls": len(self.current_session.mcp_calls),

--- a/src/vibe_check/tools/doom_loop_analysis.py
+++ b/src/vibe_check/tools/doom_loop_analysis.py
@@ -281,20 +281,20 @@ def reset_session_tracking() -> Dict[str, Any]:
         ),
     }
 
-    # Start new session
-    new_session_id = detector.start_session()
+    # Clear current session state; next tool call will auto-start a new session
+    detector.current_session = None
 
     _session_tracker = {
-        "active": True,
-        "last_call_time": time.time(),
-        "session_started": time.time(),
+        "active": False,
+        "last_call_time": None,
+        "session_started": None,
     }
 
     return {
         "status": "session_reset_complete",
-        "new_session_id": new_session_id,
+        "new_session_id": None,
         "previous_session": old_session_info,
-        "message": "✅ Fresh start! New session tracking active.",
+        "message": "✅ Fresh start! Session tracking will resume on your next tool call.",
     }
 
 

--- a/tests/integration/test_doom_loop_integration.py
+++ b/tests/integration/test_doom_loop_integration.py
@@ -96,6 +96,7 @@ class TestDoomLoopMCPIntegration:
 class TestLLMToolIntegration:
     """Test integration with LLM analysis tools"""
 
+    @pytest.mark.asyncio
     @patch("vibe_check.tools.analyze_llm.specialized_analyzers.analyze_text_llm")
     async def test_llm_tool_doom_loop_enhancement(self, mock_analyze_text):
         """Test that LLM tools are enhanced with doom loop detection"""


### PR DESCRIPTION
## Summary
- add explicit status metadata to session health reports so downstream integrations can read session state reliably
- reset session tracking now clears the active session until the next tool call and updates the user message accordingly
- mark the async LLM integration test with `pytest.mark.asyncio` so it runs under the asyncio plugin

## Testing
- `export PYTHONPATH=src:. && pytest tests/integration/test_doom_loop_integration.py -v`
- `export PYTHONPATH=src:. && pytest tests/ -q` *(stopped after ~5 minutes because the run hung waiting on additional suites)*

------
https://chatgpt.com/codex/tasks/task_b_68df0942b8d0832599a551d03b3aadf4