### PR TITLE
Handle missing stat for non-executable Claude CLI

### DIFF
--- a/src/vibe_check/tools/shared/claude_integration.py
+++ b/src/vibe_check/tools/shared/claude_integration.py
@@ -245,8 +245,12 @@ Promote good engineering practices through constructive analysis.""",
                 logger.info(f"[Info] Found Claude CLI at local user path: {user_path}")
                 return user_path
             else:
+                try:
+                    permissions = oct(os.stat(user_path).st_mode)
+                except OSError:
+                    permissions = "unknown"
                 logger.warning(
-                    f"[Warning] Claude CLI found at {user_path} but not executable. Permissions: {oct(os.stat(user_path).st_mode)}"
+                    f"[Warning] Claude CLI found at {user_path} but not executable. Permissions: {permissions}"
                 )
                 # Try to use it anyway, subprocess will fail with clear error
                 return user_path

--- a/tests/unit/test_claude_integration_issue_240.py
+++ b/tests/unit/test_claude_integration_issue_240.py
@@ -68,7 +68,9 @@ class TestClaudeCliExecutorIssue240:
             
             assert any("PATH" in msg for msg in call_messages)
             assert any("Current working directory" in msg for msg in call_messages)
-            assert any("MCP environment indicators" in msg for msg in call_messages)    @patch("shutil.which")
+            assert any("MCP environment indicators" in msg for msg in call_messages)
+
+    @patch("shutil.which")
     @patch("os.path.exists")
     @patch("os.access")
     def test_find_claude_cli_not_executable(self, mock_access, mock_exists, mock_which):
@@ -109,7 +111,9 @@ class TestClaudeCliExecutorIssue240:
             
             assert "Claude CLI not found" in error_output
             assert "Current PATH" in error_output
-            assert "To fix" in error_output    @patch("subprocess.run")
+            assert "To fix" in error_output
+
+    @patch("subprocess.run")
     def test_execute_sync_file_not_found_error(self, mock_run):
         """Test enhanced error handling for FileNotFoundError (Issue #240)."""
         mock_run.side_effect = FileNotFoundError("claude: command not found")


### PR DESCRIPTION
## Summary
- avoid raising when logging permissions for a non-executable Claude CLI path
- restore decorator placement in the issue 240 regression tests so the assertions execute

## Testing
- pytest tests/unit/test_claude_integration_issue_240.py -v
- pytest tests/unit/test_external_claude_cli.py -q
- pytest tests/ -q *(aborted after extended runtime)*

------
https://chatgpt.com/codex/tasks/task_b_68df096497bc8325b4775c1688044faf