### PR TITLE
Fix server import surface and add validation script

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,53 @@
+# Vibe Check MCP Module Architecture
+
+This document summarizes the public module layout used by integrations and test
+suites.  It focuses on the import surfaces that must remain stable after the
+recent refactor of the MCP server package.
+
+## Package Layout
+
+```
+vibe_check/
+├── __init__.py                # Core entry point exporting PatternDetector, etc.
+├── server/                    # MCP server orchestration
+│   ├── __init__.py            # Re-exports FastMCP app and mentor helpers
+│   ├── main.py                # CLI entry point for running the server
+│   ├── core.py                # FastMCP wiring and lazy initialisation
+│   ├── registry.py            # Tool registration orchestration
+│   └── tools/                 # Individual MCP tool modules
+└── mentor/                    # Collaborative reasoning system
+    ├── __init__.py            # Persona data models for external callers
+    ├── models/                # Typed dataclasses and Pydantic schemas
+    ├── mcp_sampling.py        # Secure MCP sampling client
+    └── telemetry.py           # Runtime metrics and collectors
+```
+
+The `vibe_check.server` package now provides a flat namespace for historical
+imports such as `from vibe_check.server import app` and `get_mentor_engine`.
+Likewise, `vibe_check.server.tools` and the nested `mentor` package re-export
+registration helpers and tool entry-points that the regression tests import
+directly.
+
+## Import Validation
+
+A dedicated script, `scripts/validate_imports.py`, verifies that the canonical
+modules expose the expected attributes and that their `__all__` definitions are
+kept in sync.  The script imports:
+
+- `vibe_check.server`
+- `vibe_check.server.tools`
+- `vibe_check.server.tools.mentor`
+- `vibe_check.mentor`
+- `vibe_check.tools`
+
+For each module the script checks both attribute availability and `__all__`
+contents, exiting with a non-zero status code if any mismatch is found.  This
+makes it suitable for use in CI pipelines and as a quick smoke test after local
+changes:
+
+```
+python scripts/validate_imports.py
+```
+
+When adding new public tool entry-points, update the relevant `__all__` list and
+extend the validation mapping to keep the import contract explicit.

--- a/requirements.txt
+++ b/requirements.txt
@@ -68,6 +68,10 @@ flake8>=7.1.0
 mypy>=1.13.0
 pre-commit>=4.0.0
 
+# Type stubs for strict type-checking
+types-requests>=2.32.0
+types-PyYAML>=6.0.0
+
 # Coverage and reporting
 coverage[toml]>=7.6.0
 pytest-html>=4.1.0  # HTML test reports

--- a/scripts/validate_imports.py
+++ b/scripts/validate_imports.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Validate import surfaces for the Vibe Check MCP package."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_PATH = PROJECT_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+# Map of module name to the attributes that should be publicly available.
+MODULE_EXPORTS: Dict[str, Tuple[str, ...]] = {
+    "vibe_check.server": (
+        "run_server",
+        "main",
+        "app",
+        "mcp",
+        "FastMCP",
+        "get_mcp_instance",
+        "register_all_tools",
+        "detect_transport_mode",
+        "analyze_text_demo",
+        "demo_analyze_text",
+        "server_status",
+        "get_telemetry_summary",
+        "check_integration_alternatives",
+        "vibe_check_mentor",
+        "get_mentor_engine",
+    ),
+    "vibe_check.server.tools": (
+        "register_text_analysis_tools",
+        "demo_large_prompt_handling",
+        "register_productivity_tools",
+        "reset_session_tracking",
+        "register_system_tools",
+        "server_status",
+        "get_telemetry_summary",
+        "register_context7_tools",
+        "context7_manager",
+        "register_github_tools",
+        "analyze_issue_nollm",
+        "analyze_pr_nollm",
+        "review_pr_comprehensive",
+        "register_integration_decision_tools",
+        "check_integration_alternatives",
+        "register_project_context_tools",
+        "detect_project_libraries",
+        "load_project_context",
+        "create_vibe_check_directory_structure",
+        "register_project_for_vibe_check",
+        "register_mentor_tools",
+        "vibe_check_mentor",
+    ),
+    "vibe_check.server.tools.mentor": (
+        "register_mentor_tools",
+        "vibe_check_mentor",
+        "load_workspace_context",
+        "analyze_query_and_context",
+        "get_reasoning_engine",
+        "generate_response",
+    ),
+    "vibe_check.mentor": (
+        "PersonaData",
+        "CollaborativeReasoningSession",
+        "ContributionData",
+        "DisagreementData",
+        "ConfidenceScores",
+        "ExperienceStrings",
+    ),
+    "vibe_check.tools": (
+        "analyze_text_demo",
+        "demo_analyze_text",
+    ),
+}
+
+
+@dataclass
+class ModuleReport:
+    """Represents the validation result for a single module."""
+
+    name: str
+    import_error: str | None
+    missing_attributes: List[str]
+    missing_in_all: List[str]
+
+    @property
+    def ok(self) -> bool:
+        return (
+            not self.import_error
+            and not self.missing_attributes
+            and not self.missing_in_all
+        )
+
+
+def validate_module(module_name: str, expected_exports: Iterable[str]) -> ModuleReport:
+    """Import a module and confirm the expected exports are present."""
+
+    try:
+        module = importlib.import_module(module_name)
+    except Exception as exc:  # pragma: no cover - defensive guard for CI output
+        return ModuleReport(
+            name=module_name,
+            import_error=str(exc),
+            missing_attributes=list(expected_exports),
+            missing_in_all=list(expected_exports),
+        )
+
+    missing_attributes = [
+        attr for attr in expected_exports if not hasattr(module, attr)
+    ]
+
+    module_all = getattr(module, "__all__", None)
+    if module_all is None:
+        missing_in_all = list(expected_exports)
+    else:
+        exported = set(module_all)
+        missing_in_all = [attr for attr in expected_exports if attr not in exported]
+
+    return ModuleReport(
+        name=module_name,
+        import_error=None,
+        missing_attributes=missing_attributes,
+        missing_in_all=missing_in_all,
+    )
+
+
+def main() -> int:
+    reports = [
+        validate_module(module_name, expected)
+        for module_name, expected in MODULE_EXPORTS.items()
+    ]
+
+    exit_code = 0
+    for report in reports:
+        if report.ok:
+            print(f"✅ {report.name} imports and exports verified")
+            continue
+
+        exit_code = 1
+        print(f"❌ {report.name} failed validation")
+        if report.import_error:
+            print(f"   Import error: {report.import_error}")
+        if report.missing_attributes:
+            print(f"   Missing attributes: {', '.join(report.missing_attributes)}")
+        if report.missing_in_all:
+            print(
+                "   Missing from __all__: "
+                + ", ".join(report.missing_in_all)
+            )
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/vibe_check/mentor/__init__.py
+++ b/src/vibe_check/mentor/__init__.py
@@ -18,3 +18,14 @@ __all__ = [
     "ConfidenceScores",
     "ExperienceStrings",
 ]
+
+# Backwards compatibility: inject deprecated modules into sys.modules
+# so imports like "from vibe_check.mentor.mcp_sampling_patch import X" work
+import sys
+from . import deprecated
+
+sys.modules["vibe_check.mentor.mcp_sampling_patch"] = deprecated.mcp_sampling_patch
+sys.modules["vibe_check.mentor.mcp_sampling_secure"] = deprecated.mcp_sampling_secure
+sys.modules["vibe_check.mentor.mcp_sampling_optimized"] = deprecated.mcp_sampling_optimized
+sys.modules["vibe_check.mentor.mcp_sampling_ultrafast"] = deprecated.mcp_sampling_ultrafast
+sys.modules["vibe_check.mentor.mcp_sampling_migration"] = deprecated.mcp_sampling_migration

--- a/src/vibe_check/mentor/deprecated/__init__.py
+++ b/src/vibe_check/mentor/deprecated/__init__.py
@@ -7,6 +7,12 @@ imports like ``vibe_check.mentor.deprecated.mcp_sampling_secure`` remain
 available to security regression tests and downstream extensions.
 """
 
+from . import mcp_sampling_migration
+from . import mcp_sampling_optimized
+from . import mcp_sampling_patch
+from . import mcp_sampling_secure
+from . import mcp_sampling_ultrafast
+
 __all__ = [
     "mcp_sampling_migration",
     "mcp_sampling_optimized",

--- a/src/vibe_check/server/__init__.py
+++ b/src/vibe_check/server/__init__.py
@@ -1,15 +1,39 @@
+"""Public exports for the :mod:`vibe_check.server` package.
+
+This module centralises the objects that external callers rely on so that
+historical import paths such as ``from vibe_check.server import app`` continue
+to function after the refactor that split the server into submodules.  Tests in
+``tests/unit/test_mcp_server_tools.py`` patch ``FastMCP`` and ``app`` directly
+from this package, while integrations expect to reach the mentor engine helper
+via ``vibe_check.server`` as well.  Exposing these symbols here avoids
+``AttributeError`` surprises when the package is imported in isolation (for
+example during ``python -c"from vibe_check.server import *"``).
+"""
+
 from .main import run_server, main
-from .core import mcp
+from .core import FastMCP, get_mcp_instance, mcp
 from .transport import detect_transport_mode
-from .tools.text_analysis import demo_analyze_text, analyze_text_nollm
+from .registry import register_all_tools
+from .tools.text_analysis import demo_analyze_text
 from .tools.system import server_status, get_telemetry_summary
 from .tools.integration_decisions import check_integration_alternatives
 from .tools.mentor.core import vibe_check_mentor
+from vibe_check.tools.vibe_mentor import get_mentor_engine
+
+analyze_text_demo = demo_analyze_text
+"""Backward compatible alias used throughout the test-suite."""
+
+app = mcp
+"""Expose the FastMCP instance under the historical ``app`` name."""
 
 __all__ = [
     "run_server",
     "main",
+    "app",
+    "FastMCP",
+    "get_mcp_instance",
     "mcp",
+    "register_all_tools",
     "detect_transport_mode",
     "analyze_text_demo",
     "demo_analyze_text",
@@ -17,7 +41,5 @@ __all__ = [
     "get_telemetry_summary",
     "check_integration_alternatives",
     "vibe_check_mentor",
+    "get_mentor_engine",
 ]
-
-# Backward compatibility: preserve legacy import name
-analyze_text_demo = demo_analyze_text

--- a/src/vibe_check/server/tools/__init__.py
+++ b/src/vibe_check/server/tools/__init__.py
@@ -1,0 +1,68 @@
+"""Public exports for server-side MCP tools.
+
+Historically the tooling module exposed a flat namespace that callers could
+import from (``from vibe_check.server.tools import register_text_analysis_tools``).
+The refactor that introduced the ``tools`` package left this file empty which in
+turn caused ``AttributeError`` during star-import validation.  The utilities
+below surface the key registration helpers and tool entry-points so the package
+behaves like the pre-refactor module again.
+"""
+
+from .context7_integration import (
+    Context7Manager,
+    context7_manager,
+    register_context7_tools,
+)
+from .github_integration import (
+    register_github_tools,
+    analyze_issue_nollm,
+    analyze_pr_nollm,
+    review_pr_comprehensive,
+)
+from .integration_decisions import (
+    check_integration_alternatives,
+    register_integration_decision_tools,
+)
+from .mentor.core import register_mentor_tools, vibe_check_mentor
+from .productivity import (
+    register_productivity_tools,
+    reset_session_tracking,
+)
+from .project_context import (
+    register_project_context_tools,
+    detect_project_libraries,
+    load_project_context,
+    create_vibe_check_directory_structure,
+    register_project_for_vibe_check,
+)
+from .system import register_system_tools, server_status, get_telemetry_summary
+from .text_analysis import (
+    register_text_analysis_tools,
+    demo_large_prompt_handling,
+)
+
+__all__ = [
+    "Context7Manager",
+    "context7_manager",
+    "register_context7_tools",
+    "register_github_tools",
+    "analyze_issue_nollm",
+    "analyze_pr_nollm",
+    "review_pr_comprehensive",
+    "check_integration_alternatives",
+    "register_integration_decision_tools",
+    "register_mentor_tools",
+    "vibe_check_mentor",
+    "register_productivity_tools",
+    "reset_session_tracking",
+    "register_project_context_tools",
+    "detect_project_libraries",
+    "load_project_context",
+    "create_vibe_check_directory_structure",
+    "register_project_for_vibe_check",
+    "register_system_tools",
+    "server_status",
+    "get_telemetry_summary",
+    "register_text_analysis_tools",
+    "demo_large_prompt_handling",
+]

--- a/src/vibe_check/server/tools/mentor/__init__.py
+++ b/src/vibe_check/server/tools/mentor/__init__.py
@@ -1,0 +1,21 @@
+"""Mentor tool exports.
+
+Keeping these re-exports together makes it easy for callers to import the
+mentor MCP tool without having to know the internal folder layout.  This mirrors
+the legacy behaviour of ``vibe_check.server.tools.mentor`` that tests and
+external integrations relied upon.
+"""
+
+from .core import register_mentor_tools, vibe_check_mentor
+from .context import load_workspace_context
+from .analysis import analyze_query_and_context
+from .reasoning import get_reasoning_engine, generate_response
+
+__all__ = [
+    "register_mentor_tools",
+    "vibe_check_mentor",
+    "load_workspace_context",
+    "analyze_query_and_context",
+    "get_reasoning_engine",
+    "generate_response",
+]


### PR DESCRIPTION
## Summary
- restore the public exports in `vibe_check.server` so legacy imports like `app`, `FastMCP`, and `get_mentor_engine` succeed
- expose the tool registration helpers in `vibe_check.server.tools` and its mentor subpackage
- add a CI-friendly `scripts/validate_imports.py` runner and document the module structure in `docs/ARCHITECTURE.md`
- include type stub dependencies needed for strict type checking

## Testing
- `python scripts/validate_imports.py`
- `PYTHONPATH=src python -c "from vibe_check.mentor import *; print('OK')"`
- `PYTHONPATH=src python -c "from vibe_check.server import *; print('OK')"`
- `PYTHONPATH=src pytest tests/security/test_mcp_sampling_security.py tests/security/test_security_regression.py tests/unit/test_vibe_mentor_context_aware.py --collect-only`
- `PYTHONPATH=src pytest tests/security/ tests/unit/ -x`


------
https://chatgpt.com/codex/tasks/task_b_68df12eb5ff88325b0a8df02c9393cf4