### PR TITLE
test(issue-analysis): hermetic analyzer fixtures

### DIFF
--- a/tests/unit/test_global_analyzer_instance.py
+++ b/tests/unit/test_global_analyzer_instance.py
@@ -17,14 +17,17 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
 
 from vibe_check.tools.analyze_issue import get_github_analyzer
 import vibe_check.tools.analyze_issue as analyze_issue_module
+import vibe_check.tools.issue_analysis.api as issue_analysis_api
 
 
 @pytest.fixture(autouse=True)
 def reset_singleton():
     """Reset singleton cache before each test"""
     analyze_issue_module._enhanced_github_analyzer = None
+    issue_analysis_api._enhanced_github_analyzer = None
     yield
     analyze_issue_module._enhanced_github_analyzer = None
+    issue_analysis_api._enhanced_github_analyzer = None
 
 
 class TestGlobalAnalyzerInstance:
@@ -33,7 +36,7 @@ class TestGlobalAnalyzerInstance:
     def test_get_github_analyzer_singleton(self):
         """Test that get_github_analyzer returns singleton instance"""
         with patch(
-            "vibe_check.tools.analyze_issue.EnhancedGitHubIssueAnalyzer"
+            "vibe_check.tools.issue_analysis.api.EnhancedGitHubIssueAnalyzer"
         ) as mock_analyzer_class:
             mock_instance = MagicMock()
             mock_analyzer_class.return_value = mock_instance
@@ -51,7 +54,7 @@ class TestGlobalAnalyzerInstance:
     def test_get_github_analyzer_with_token(self):
         """Test get_github_analyzer with specific token on first call"""
         with patch(
-            "vibe_check.tools.analyze_issue.EnhancedGitHubIssueAnalyzer"
+            "vibe_check.tools.issue_analysis.api.EnhancedGitHubIssueAnalyzer"
         ) as mock_analyzer_class:
             mock_instance = MagicMock()
             mock_analyzer_class.return_value = mock_instance
@@ -66,7 +69,7 @@ class TestGlobalAnalyzerInstance:
     def test_get_github_analyzer_token_override(self):
         """Test that providing token on subsequent calls is ignored due to caching"""
         with patch(
-            "vibe_check.tools.analyze_issue.EnhancedGitHubIssueAnalyzer"
+            "vibe_check.tools.issue_analysis.api.EnhancedGitHubIssueAnalyzer"
         ) as mock_analyzer_class:
             mock_instance = MagicMock()
             mock_analyzer_class.return_value = mock_instance


### PR DESCRIPTION
## Summary
- Align unit fixtures with the hermetic GitHub mocks (`html_url`, structured labels, logged-in user)
- Compare against real `IssueLabel` objects while preserving the original `fetch_issue_data`
- Keep global analyzer singleton tests hermetic by patching the API-level factory

## Validation
- `pytest tests/unit/test_github_issue_analyzer.py tests/unit/test_global_analyzer_instance.py -o addopts='--strict-markers --strict-config --verbose --tb=short --durations=10 --ignore=src/vibe_check/logs/ --ignore=examples/ --ignore=validation/'`
- Full `pytest` suite still times out because async-analysis workers never stop (known follow-up)

## Follow-ups
- Track repo-wide lint/type debt and async-analysis suite hangs: https://github.com/kesslerio/vibe-check-mcp/issues/292
